### PR TITLE
fix: Improper Encoding or Escaping of Output

### DIFF
--- a/articles/llama-chatbot-flows/main.py
+++ b/articles/llama-chatbot-flows/main.py
@@ -8,7 +8,7 @@ import uuid
 
 import requests
 from dotenv import load_dotenv
-from flask import Flask, json, make_response, request
+from flask import Flask, json, make_response, request, escape
 from llama_cpp import Llama
 
 app = Flask(__name__)
@@ -39,7 +39,7 @@ def webhook_get():
             request.args.get("hub.mode") == "subscribe"
             and request.args.get("hub.verify_token") == TOKEN
         ):
-            return make_response(request.args.get("hub.challenge"), 200)
+            return make_response(escape(request.args.get("hub.challenge")), 200)
         else:
             return make_response("Success", 403)
 


### PR DESCRIPTION
fix the reflected server-side XSS vulnerability, we should escape the value of `request.args.get("hub.challenge")` before including it in the response. Since the code uses Flask, the recommended way is to use `flask.escape()` to sanitize the value. This change should be made in the `webhook_get` function, specifically on line 42. We need to import `escape` from `flask` if it is not already imported. The only required code change is to wrap the value with `escape()` before passing it to `make_response`.
